### PR TITLE
Remove "Religion" as a topic.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: Implementation :: CPython",
-        "Topic :: Religion",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Topic :: Text Processing :: Linguistic",
         "Topic :: Text Processing :: Markup :: XML",


### PR DESCRIPTION
"Religion" seems to be a topic as a joke, but this is polluting the PyPi namespace. Cleaning it up.